### PR TITLE
RDKB-60325 : notify_tunnel_status failure in hotspot

### DIFF
--- a/source/mocks_CcspCommonLibrary/mock_base_api.cpp
+++ b/source/mocks_CcspCommonLibrary/mock_base_api.cpp
@@ -254,3 +254,12 @@ extern "C" void free_parameterInfoStruct_t (void* bus_handle, int size, paramete
     }
     return g_baseapiMock->free_parameterInfoStruct_t(bus_handle, size, val);
 }
+
+extern "C" int CcspBaseIf_SendSignal_WithData_rbus(void* bus_handle, char *event, char* data)
+{
+    if (!g_baseapiMock)
+    {
+        return -1;
+    }
+    return g_baseapiMock->CcspBaseIf_SendSignal_WithData_rbus(bus_handle, event, data);
+}

--- a/source/mocks_CcspCommonLibrary/mock_base_api.h
+++ b/source/mocks_CcspCommonLibrary/mock_base_api.h
@@ -47,6 +47,8 @@ public:
         virtual int PSM_Del_Record(void* , const char* , const char* ) = 0;
         virtual int CcspBaseIf_GetNextLevelInstances(void* ,const char* ,char* ,char* ,unsigned int* ,unsigned int**) = 0;
         virtual void free_parameterInfoStruct_t (void*, int, parameterInfoStruct_t **) = 0;
+        virtual int CcspBaseIf_SendSignal_WithData_rbus(void*, char *, char*) = 0;
+
 };
 
 
@@ -69,6 +71,7 @@ public:
         MOCK_METHOD3(PSM_Del_Record, int(void* , const char* , const char* ));
         MOCK_METHOD6(CcspBaseIf_GetNextLevelInstances, int(void* ,const char* ,char* ,char* ,unsigned int* ,unsigned int**));
         MOCK_METHOD3(free_parameterInfoStruct_t, void(void*, int, parameterInfoStruct_t **));
+        MOCK_METHOD3(CcspBaseIf_SendSignal_WithData_rbus, int(void*, char *, char*));
 };
 
 #endif


### PR DESCRIPTION
Reason for change: notify_tunnel_status fails in hotspot Test Procedure: TunnelStatus should get notified
Risks: Low
Priority: P2
Signed-off-by:sowmiya_chelliah@comcast.com